### PR TITLE
Optional args

### DIFF
--- a/code/BuildTasks/PurgeTwitter.php
+++ b/code/BuildTasks/PurgeTwitter.php
@@ -20,8 +20,7 @@ class PurgeTwitter extends BuildTask {
         $this->run();
     }
 
-    public function run($request) {
-
+    public function run($request = null) {
         // eol
         $eol = php_sapi_name() == 'cli' ? "\n" : "<br>\n";
 

--- a/code/BuildTasks/RetrySyncFacebookImages.php
+++ b/code/BuildTasks/RetrySyncFacebookImages.php
@@ -49,7 +49,7 @@ class RetrySyncFacebookImages extends BuildTask implements CronTask {
         $this->run();
     }
 
-    function run($request) {
+    public function run($request = null) {
 
         // eol
         $eol = php_sapi_name() == 'cli' ? "\n" : "<br>\n";

--- a/code/BuildTasks/SyncFacebook.php
+++ b/code/BuildTasks/SyncFacebook.php
@@ -57,7 +57,7 @@ class SyncFacebook extends BuildTask implements CronTask {
 
     function init() {
 
-        if (method_exists(parent,'init')) parent::init();
+        if (method_exists(get_parent_class($this), 'init')) parent::init();
 
         if (!Director::is_cli() && !Permission::check("ADMIN") && $_SERVER['REMOTE_ADDR'] != $_SERVER['SERVER_ADDR']) {
             return Security::permissionFailure();
@@ -72,7 +72,7 @@ class SyncFacebook extends BuildTask implements CronTask {
         $this->run();
     }
 
-    function run($request) {
+    function run($request = null) {
 
         // output
         echo "<br />\n<br />\nSyncing...<br />\n<br />\n";

--- a/code/BuildTasks/SyncInstagram.php
+++ b/code/BuildTasks/SyncInstagram.php
@@ -58,7 +58,7 @@ class SyncInstagram extends BuildTask implements CronTask{
         $this->run();
     }
 
-    public function run($request) {
+    public function run($request = null) {
 
         // output
         echo "<br />\n<br />\nSyncing...<br />\n<br />\n";

--- a/code/BuildTasks/SyncTwitter.php
+++ b/code/BuildTasks/SyncTwitter.php
@@ -62,7 +62,7 @@ class SyncTwitter extends BuildTask implements CronTask{
         $this->run();
     }
 
-    public function run($request) {
+    public function run($request = null) {
 
         // output
         echo "<br />\n<br />\nSyncing...<br />\n<br />\n";


### PR DESCRIPTION
PHP 7.1 generates an error rather than a warning for incorrect params.